### PR TITLE
Adjust sources to use include/hardware from repo instead of the syste…

### DIFF
--- a/audio_hal_interface/Android.bp
+++ b/audio_hal_interface/Android.bp
@@ -5,6 +5,7 @@ cc_library_static {
     defaults: ["fluoride_defaults_qti"],
     include_dirs: [
         "vendor/qcom/opensource/commonsys/system/bt",
+        "vendor/qcom/opensource/commonsys/system/bt/include",
         "vendor/qcom/opensource/commonsys/system/bt/bta/include",
         "vendor/qcom/opensource/commonsys/system/bt/bta/sys",
         "vendor/qcom/opensource/commonsys/bluetooth_ext/vhal/include/",

--- a/audio_hal_interface/a2dp_encoding.cc
+++ b/audio_hal_interface/a2dp_encoding.cc
@@ -247,10 +247,10 @@ SampleRate a2dp_codec_to_hal_sample_rate(
       return SampleRate::RATE_176400;
     case BTAV_A2DP_CODEC_SAMPLE_RATE_192000:
       return SampleRate::RATE_192000;
-    case BTAV_A2DP_CODEC_SAMPLE_RATE_16000:
-      return SampleRate::RATE_16000;
-    case BTAV_A2DP_CODEC_SAMPLE_RATE_24000:
-      return SampleRate::RATE_24000;
+    // case BTAV_A2DP_CODEC_SAMPLE_RATE_16000:
+    //   return SampleRate::RATE_16000;
+    // case BTAV_A2DP_CODEC_SAMPLE_RATE_24000:
+    //   return SampleRate::RATE_24000;
     default:
       return SampleRate::RATE_UNKNOWN;
   }
@@ -415,9 +415,9 @@ bool a2dp_is_audio_codec_config_params_changed(
       }
       break;
     }
-    case BTAV_A2DP_CODEC_INDEX_SOURCE_AAC:
-      [[fallthrough]];
-    case BTAV_A2DP_CODEC_INDEX_SINK_AAC: {
+    case BTAV_A2DP_CODEC_INDEX_SOURCE_AAC: {
+    //   [[fallthrough]];
+    // case BTAV_A2DP_CODEC_INDEX_SINK_AAC: {
       if(codec_config->codecType != CodecType::AAC) {
         changed = true;
         break;
@@ -732,9 +732,9 @@ bool a2dp_get_selected_hal_codec_config(CodecConfiguration* codec_config) {
       break;
     }
 
-    case BTAV_A2DP_CODEC_INDEX_SOURCE_AAC:
-      [[fallthrough]];
-    case BTAV_A2DP_CODEC_INDEX_SINK_AAC: {
+    case BTAV_A2DP_CODEC_INDEX_SOURCE_AAC: {
+    //   [[fallthrough]];
+    // case BTAV_A2DP_CODEC_INDEX_SINK_AAC: {
       codec_config->codecType = CodecType::AAC;
       codec_config->config.aacConfig = {};
       auto aac_config = codec_config->config.aacConfig;

--- a/btif/Android.bp
+++ b/btif/Android.bp
@@ -2,6 +2,7 @@
 // ========================================================
 btifCommonIncludes = [
     "vendor/qcom/opensource/commonsys/system/bt",
+    "vendor/qcom/opensource/commonsys/system/bt/include",
     "vendor/qcom/opensource/commonsys/system/bt/bta/include",
     "vendor/qcom/opensource/commonsys/system/bt/bta/ag",
     "vendor/qcom/opensource/commonsys/system/bt/bta/sys",

--- a/btif/src/bluetooth.cc
+++ b/btif/src/bluetooth.cc
@@ -490,10 +490,10 @@ static std::string obfuscate_address(const RawAddress& address) {
       address);
 }
 
-static int get_metric_id(const RawAddress& address) {
-  LOG_ERROR(LOG_TAG, "%s: not implemented", __func__);
-  return 0;
-}
+// static int get_metric_id(const RawAddress& address) {
+//   LOG_ERROR(LOG_TAG, "%s: not implemented", __func__);
+//   return 0;
+// }
 
 EXPORT_SYMBOL bt_interface_t bluetoothInterface = {
     sizeof(bluetoothInterface),
@@ -531,5 +531,5 @@ EXPORT_SYMBOL bt_interface_t bluetoothInterface = {
     interop_database_add,
     get_avrcp_service,
     obfuscate_address,
-    get_metric_id,
+    //    get_metric_id,
 };

--- a/btif/src/btif_av.cc
+++ b/btif/src/btif_av.cc
@@ -4384,8 +4384,8 @@ static bt_status_t init_src(
 static bt_status_t init_src(
     btav_source_callbacks_t* callbacks,
     int max_connected_audio_devices,
-    const std::vector<btav_a2dp_codec_config_t> &codec_priorities,
-    const std::vector<btav_a2dp_codec_config_t> &offload_enabled_codecs) {
+    std::vector<btav_a2dp_codec_config_t> &codec_priorities/*,
+                                                                   const std::vector<btav_a2dp_codec_config_t> &offload_enabled_codecs*/) {
   int a2dp_multicast_state = controller_get_interface()->is_multicast_enabled();
   if(max_connected_audio_devices > BTIF_AV_NUM_CB) {
     BTIF_TRACE_ERROR("%s: App setting maximum allowable connections(%d) \
@@ -4410,7 +4410,7 @@ static bt_status_t init_src(
     collision_detect[i].conn_retry_count = 1;
     collision_detect[i].av_coll_detected_timer = NULL;
   }
-  return init_src(callbacks, codec_priorities, offload_enabled_codecs,
+  return init_src(callbacks, codec_priorities, {},
                 max_connected_audio_devices, a2dp_multicast_state);
 }
 
@@ -4705,16 +4705,16 @@ static bt_status_t sink_disconnect_src(const RawAddress& bd_addr) {
  * Returns          bt_status_t
  *
  ******************************************************************************/
-static bt_status_t set_silence_device(const RawAddress& bd_addr, bool silence) {
-  BTIF_TRACE_EVENT("%s silence = %d", __func__, silence);
-  CHECK_BTAV_INIT();
+// static bt_status_t set_silence_device(const RawAddress& bd_addr, bool silence) {
+//   BTIF_TRACE_EVENT("%s silence = %d", __func__, silence);
+//   CHECK_BTAV_INIT();
 
-  btif_av_silent_req_t silent_req;
-  silent_req.bd_addr = bd_addr;
-  silent_req.is_silent = silence;
-  return btif_transfer_context(btif_av_handle_event, BTIF_AV_SET_SILENT_REQ_EVT,
-                               (char *)&silent_req, sizeof(silent_req), NULL);
-}
+//   btif_av_silent_req_t silent_req;
+//   silent_req.bd_addr = bd_addr;
+//   silent_req.is_silent = silence;
+//   return btif_transfer_context(btif_av_handle_event, BTIF_AV_SET_SILENT_REQ_EVT,
+//                                (char *)&silent_req, sizeof(silent_req), NULL);
+// }
 
 /*******************************************************************************
  *
@@ -4978,7 +4978,7 @@ static const btav_source_interface_t bt_av_src_interface = {
     init_src,
     src_connect_sink,
     src_disconnect_sink,
-    set_silence_device,
+    // set_silence_device,
     set_active_device,
     codec_config_src,
     cleanup_src,
@@ -4996,7 +4996,7 @@ static const btav_sink_interface_t bt_av_sink_interface = {
     cleanup_sink,
     update_audio_focus_state,
     update_audio_track_gain,
-    set_active_device,
+    //    set_active_device,
 };
 
 RawAddress btif_av_get_addr_by_index(int idx) {

--- a/btif/src/btif_ble_advertiser.cc
+++ b/btif/src/btif_ble_advertiser.cc
@@ -248,7 +248,7 @@ class BleAdvertiserInterfaceImpl : public BleAdvertiserInterface {
                           jni_thread_wrapper(FROM_HERE, cb)));
   }
 
-  void CreateBIG(int advertiser_id, CreateBIGParameters create_big_params,
+    /*  void CreateBIG(int advertiser_id, CreateBIGParameters create_big_params,
                  CreateBIGCallback cb) override {
     VLOG(1) << __func__ << " advertiser_id: " << +advertiser_id;
   }
@@ -256,7 +256,7 @@ class BleAdvertiserInterfaceImpl : public BleAdvertiserInterface {
   void TerminateBIG(int advertiser_id, int big_handle, int reason,
                     TerminateBIGCallback cb) override {
     VLOG(1) << __func__ << "big_handle: " << +big_handle;
-  }
+    }*/
 
 };
 

--- a/btif/src/btif_gatt_client.cc
+++ b/btif/src/btif_gatt_client.cc
@@ -230,13 +230,13 @@ void btm_read_rssi_cb(void* p_void) {
  *  Client API Functions
  ******************************************************************************/
 
-bt_status_t btif_gattc_register_app(const Uuid& uuid, bool eatt_support) {
+bt_status_t btif_gattc_register_app(const Uuid& uuid/*, bool eatt_support*/) {
   CHECK_BTGATT_INIT();
 
-  if (eatt_support) {
+  /*  if (eatt_support) {
     LOG_ERROR(LOG_TAG, "%s: EATT not supported", __func__);
     return BT_STATUS_UNSUPPORTED;
-  }
+    }*/
 
   return do_in_jni_thread(Bind(
       [](const Uuid& uuid) {

--- a/btif/src/btif_gatt_server.cc
+++ b/btif/src/btif_gatt_server.cc
@@ -275,13 +275,13 @@ static void btapp_gatts_cback(tBTA_GATTS_EVT event, tBTA_GATTS* p_data) {
 /*******************************************************************************
  *  Server API Functions
  ******************************************************************************/
-static bt_status_t btif_gatts_register_app(const Uuid& bt_uuid, bool eatt_support) {
+static bt_status_t btif_gatts_register_app(const Uuid& bt_uuid/*, bool eatt_support*/) {
   CHECK_BTGATT_INIT();
 
-  if (eatt_support) {
-    LOG_ERROR(LOG_TAG, "%s: EATT not supported", __func__);
-    return BT_STATUS_UNSUPPORTED;
-  }
+  // if (eatt_support) {
+  //   LOG_ERROR(LOG_TAG, "%s: EATT not supported", __func__);
+  //   return BT_STATUS_UNSUPPORTED;
+  // }
 
   return do_in_jni_thread(
       Bind(&BTA_GATTS_AppRegister, bt_uuid, &btapp_gatts_cback));

--- a/stack/Android.bp
+++ b/stack/Android.bp
@@ -34,6 +34,7 @@ cc_library_static {
         "external/libldac/inc",
         "external/libldac/abr/inc",
         "vendor/qcom/opensource/commonsys/system/bt",
+        "vendor/qcom/opensource/commonsys/system/bt/include",
         "vendor/qcom/opensource/commonsys/system/bt/btcore/include",
         "vendor/qcom/opensource/commonsys/system/bt/vnd/include",
         "vendor/qcom/opensource/commonsys/system/bt/vnd/ble",


### PR DESCRIPTION
…m one.

This is an attempt to compile this part for Sony seine. @jerpelea, this is following sonyxperiadev/vendor-qcom-opensource-bluetooth#4. To get it compile, I've added this to `device/sony/pdx201/aosp_xqau52.mk`:
```
TARGET_FWK_SUPPORTS_FULL_VALUEADDS := true
$(call inherit-product, vendor/qcom/opensource/commonsys-intf/bluetooth/bt-commonsys-intf-board.mk)
$(call inherit-product, vendor/qcom/opensource/commonsys-intf/bluetooth/bt-system-opensource-product.mk)
```

The changes are done to make it compile, but I'm not sure they are actually correct. Basically, there are some discrepencies between the header files in `include/hardware/*.h` and the actual sources. But the sources are not fit for `$ANDROID_ROOT/system/include/hardware/*.h` neither. What is the correct route here ? Should we update to the latest upstream from https://github.com/LineageOS/android_vendor_qcom_opensource_system_bt or are we stuck at a specific tag ?